### PR TITLE
Add a policy to only allow 4 concurrent build actions

### DIFF
--- a/policies/build.yaml
+++ b/policies/build.yaml
@@ -1,0 +1,9 @@
+name: build.concurrency
+description: Limits concurrent openioci.build executions.
+enabled: true
+resource_ref: openioci.build
+policy_type: action.concurrency
+parameters:
+    action: delay
+    threshold: 4
+


### PR DESCRIPTION
The plugging of github webhook made the unbounded build actions
overrun the openstack quota (for disk volumes total size).

This enforces a limit of 4 concurrent builds which won't be too
heavy on our current openstack infrastructure. This should be a
safe baseline.

The subsequent requested build actions will be queued until one
finishes.