### PR TITLE
Use "oiobuild.slack_dedup" to deduplicate messages sent via slack

### DIFF
--- a/actions/build.yaml
+++ b/actions/build.yaml
@@ -18,6 +18,7 @@ notify:
     data:
       channel: '#github'
       username: 'nightly-build'
+      store_key: 'build_n_test'
   on-failure:
     routes:
       - slackbuild
@@ -25,3 +26,4 @@ notify:
     data:
       channel: '#github'
       username: 'nightly-build'
+      store_key: 'build_n_test'

--- a/rules/slack_notify.yaml
+++ b/rules/slack_notify.yaml
@@ -14,10 +14,11 @@ criteria:
     type: equals
 
 action:
-  ref: slack.post_message
+  ref: oiobuild.slack_dedup
   parameters:
     username: '{{trigger.data.username}}'
     message: '{{trigger.message}}'
     channel: '{{trigger.data.channel}}'
+    store_key: '{{trigger.data.store_key}}'
 
 ...


### PR DESCRIPTION
This will keep messages in the KV store and compare new & old ones to decide if it needs to send it via slack

The external dependency on oiobuild will solve itself when openioci & oiobuild are integrated back into a single pack.